### PR TITLE
DRYD-1133: Add fieldCollectionEvent

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -708,6 +708,30 @@ export default (configContext) => {
             },
           },
         },
+        fieldCollectionEvents: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          fieldCollectionEvent: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.collectionobjects_anthro.fieldCollectionEvent.name',
+                  defaultMessage: 'Field collection event',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: AutocompleteInput,
+                props: {
+                  source: 'chronology/fieldcollection,chronology/event'
+                },
+              },
+            },
+          },
+        },
         // FIXME: Locality was added for DRYD-400, but I didn't realize locality was already
         // included by the naturalhistory extension, so the locality fields are duplicated in both
         // collectionobjects_naturalhistory_extension and collectionobjects_anthro.

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -726,7 +726,7 @@ export default (configContext) => {
               view: {
                 type: AutocompleteInput,
                 props: {
-                  source: 'chronology/fieldcollection,chronology/event'
+                  source: 'chronology/fieldcollection,chronology/event',
                 },
               },
             },

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -162,6 +162,10 @@ const template = (configContext) => {
       <Panel name="collect" collapsible collapsed>
         <Row>
           <Col>
+            <Field name="fieldCollectionSites">
+              <Field name="fieldCollectionSite" />
+            </Field>
+
             <Field name="fieldCollectionDateGroup" />
 
             <Field name="fieldCollectionMethods">

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -187,6 +187,10 @@ const template = (configContext) => {
               <Field name="fieldColEventName" />
             </Field>
 
+            <Field name="fieldCollectionEvents" subpath="ns2:collectionobjects_anthro">
+              <Field name="fieldCollectionEvent" />
+            </Field>
+
             <Field name="fieldCollectionFeature" />
             <Field name="fieldCollectionNote" />
           </Col>


### PR DESCRIPTION
**What does this do?**
Add fieldCollectionEvent to collectionobject

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/jira/software/c/projects/DRYD/issues/DRYD-1133

As part of the work for the chronology authority we're adding a field to collection object which makes use of chronologies.

**How should this be tested? Do these changes have associated tests?**
* Build collection space
* Run the anthro ui profile
* Create a collectionobject and add a field collection or event chronology to the `fieldCollectionEvent` field
* Save and reload the collectionobject to ensure the changes persisted correctly

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter Tested that the collectionobject can save and load a chronology in the new field