### PR TITLE
DRYD-1256: Add objectProductionEra

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -211,6 +211,10 @@ const template = (configContext) => {
               <Field name="objectProductionDateGroup" />
             </Field>
 
+            <Field name="objectProductionEras">
+              <Field name="objectProductionEra" />
+            </Field>
+
             <Field name="techniqueGroupList">
               <Field name="techniqueGroup">
                 <Field name="technique" />


### PR DESCRIPTION
**What does this do?**
Adds objectProductionEra to the default collectionobject form.

**Why are we doing this? (with JIRA link)**
This field was added as part of the Chronology additions, and was missing in the anthro profile.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver: `npm run devserver`
* Navigate to collectionobject > Object Production Information
* Add one or more entries to the `Production Era` form entry
  * Note that these should use chronology/era
* Verify the collectionobject saves and the newly added eras persist 

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance