### PR TITLE
DRYD-1261: Add fieldcollection to anthro

### DIFF
--- a/src/plugins/recordTypes/chronology/index.js
+++ b/src/plugins/recordTypes/chronology/index.js
@@ -1,0 +1,9 @@
+import vocabularies from './vocabularies';
+
+export default () => ({
+  recordTypes: {
+    chronology: {
+      vocabularies,
+    },
+  },
+});

--- a/src/plugins/recordTypes/chronology/vocabularies.js
+++ b/src/plugins/recordTypes/chronology/vocabularies.js
@@ -1,0 +1,26 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  fieldcollection: {
+    messages: defineMessages({
+      name: {
+        id: 'vocab.chronology.fieldcollection.name',
+        description: 'The name of the vocabulary.',
+        defaultMessage: 'Field Collection',
+      },
+      collectionName: {
+        id: 'vocab.chronology.fieldcollection.collectionName',
+        description: 'The name of a collection of records from the vocabulary.',
+        defaultMessage: 'Field Collection Chronologies',
+      },
+      itemName: {
+        id: 'vocab.chronology.fieldcollection.itemName',
+        description: 'The name of a record from the vocabulary.',
+        defaultMessage: 'Field Collection Chronology',
+      },
+    }),
+    serviceConfig: {
+      servicePath: 'urn:cspace:name(field_collection)',
+    },
+  },
+};

--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -1,3 +1,4 @@
+import chronology from './chronology';
 import claim from './claim';
 import collectionobject from './collectionobject';
 import concept from './concept';
@@ -7,6 +8,7 @@ import person from './person';
 import place from './place';
 
 export default [
+  chronology,
   claim,
   collectionobject,
   concept,


### PR DESCRIPTION
**What does this do?**
Adds the chronology fieldcollection authority

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1261

This authority was only being used in the anthro profile, so it has been removed from core and added to anthro.

**How should this be tested? Do these changes have associated tests?**
* Build collectionspace using the 7.2 QA PR
* Run the devserver
* Verify that chronology fieldcollection authorities can be created

**Dependencies for merging? Releasing to production?**
Probably a good idea to bring in the 7.2 QA PR cspace-ui changes as well for consistency with other changes to chronology.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance