### PR TITLE
DRYD-1317: Relable Ethnographic File Code to Function

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -207,7 +207,7 @@ export default (configContext) => {
               messages: defineMessages({
                 name: {
                   id: 'field.collectionobjects_anthro.ethnoFileCode.name',
-                  defaultMessage: 'Ethnographic file code',
+                  defaultMessage: 'Function',
                 },
               }),
               repeating: true,

--- a/src/plugins/recordTypes/concept/vocabularies.js
+++ b/src/plugins/recordTypes/concept/vocabularies.js
@@ -50,17 +50,17 @@ export default {
       name: {
         id: 'vocab.concept.ethfilecode.name',
         description: 'The name of the ethfilecode concept vocabulary.',
-        defaultMessage: 'Ethnographic File Code',
+        defaultMessage: 'Function',
       },
       collectionName: {
         id: 'vocab.concept.ethfilecode.collectionName',
         description: 'The name of a collection of records from the ethfilecode concept vocabulary.',
-        defaultMessage: 'Ethnographic File Codes',
+        defaultMessage: 'Functions',
       },
       itemName: {
         id: 'vocab.concept.ethfilecode.itemName',
         description: 'The name of a record from the vocabulary.',
-        defaultMessage: 'Ethnographic File Code',
+        defaultMessage: 'Function',
       },
     }),
     serviceConfig: {


### PR DESCRIPTION
**What does this do?**
Relabels EthnoGraphic File Code to Function

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1317

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* See the labels updated to be 'Function'

**Dependencies for merging? Releasing to production?**
It would probably be nice to update the ids and messages for the vocabulary changes, but the authority itself is still referred to as ethfilecode so I don't think we can. 

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter Tested against a local server