### PR TITLE
DRYD-1374: ObjectCountGroup fields for collectionobject

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -29,7 +29,6 @@ const template = (configContext) => {
         <Row>
           <Col>
             <Field name="objectNumber" />
-            <Field name="numberOfObjects" />
 
             <Field name="otherNumberList">
               <Field name="otherNumber">

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -90,6 +90,16 @@ const template = (configContext) => {
           </Field>
         </Field>
 
+        <Field name="objectCountGroupList">
+          <Field name="objectCountGroup">
+            <Field name="objectCount" />
+            <Field name="objectCountType" />
+            <Field name="objectCountCountedBy" />
+            <Field name="objectCountDate" />
+            <Field name="objectCountNote" />
+          </Field>
+        </Field>
+
         <Cols>
           <Col>
             <Field name="assocPeopleGroupList">


### PR DESCRIPTION
**What does this do?**
* Add objectCountGroupList to the collectionobject form
* Removes numberOfObjects

**Why are we doing this? (with JIRA link)**
This is a combination of 2 jiras:
* https://collectionspace.atlassian.net/browse/DRYD-1374
* https://collectionspace.atlassian.net/browse/DRYD-1379

This replaces the use of numberOfObjects with the new object count fields.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Add a object count
* Observer that numberOfObjects no longer displays

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally