### PR TITLE
Update associated authorities for chronology, person, and place

### DIFF
--- a/src/plugins/extensions/associatedAuthority/fields.js
+++ b/src/plugins/extensions/associatedAuthority/fields.js
@@ -4,6 +4,19 @@ export default (configContext) => {
   } = configContext.configHelpers;
 
   return {
+    assocConceptAuthGroupList: {
+      assocConceptAuthGroup: {
+        assocConcept: {
+          [config]: {
+            view: {
+              props: {
+                source: 'concept/activity,concept/associated,concept/material,concept/nomenclature,concept/occasion,concept/archculture',
+              },
+            },
+          },
+        },
+      },
+    },
     assocChronologyAuthGroupList: {
       assocChronologyAuthGroup: {
         assocChronology: {

--- a/src/plugins/extensions/associatedAuthority/fields.js
+++ b/src/plugins/extensions/associatedAuthority/fields.js
@@ -1,0 +1,21 @@
+export default (configContext) => {
+  const {
+    configKey: config,
+  } = configContext.configHelpers;
+
+  return {
+    assocChronologyAuthGroupList: {
+      assocChronologyAuthGroup: {
+        assocChronology: {
+          [config]: {
+            view: {
+              props: {
+                source: 'chronology/era,chronology/event,chronology/fieldcollection',
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};

--- a/src/plugins/extensions/associatedAuthority/index.js
+++ b/src/plugins/extensions/associatedAuthority/index.js
@@ -1,0 +1,9 @@
+import fields from './fields';
+
+export default () => (configContext) => ({
+  extensions: {
+    associatedAuthority: {
+      fields: fields(configContext),
+    },
+  },
+});

--- a/src/plugins/extensions/index.js
+++ b/src/plugins/extensions/index.js
@@ -1,0 +1,5 @@
+import associatedAuthority from './associatedAuthority';
+
+export default [
+  associatedAuthority,
+];

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,5 +1,7 @@
+import extensions from './extensions';
 import recordTypes from './recordTypes';
 
 export default [
+  ...extensions,
   ...recordTypes,
 ];

--- a/src/plugins/recordTypes/chronology/fields.js
+++ b/src/plugins/recordTypes/chronology/fields.js
@@ -5,8 +5,7 @@ export default (configContext) => {
 
   return {
     document: {
-      ...extensions.nagpra.place.fields,
-      'ns2:places_common': {
+      'ns2:chronologies_common': {
         ...extensions.associatedAuthority.fields,
       },
     },

--- a/src/plugins/recordTypes/chronology/index.js
+++ b/src/plugins/recordTypes/chronology/index.js
@@ -1,8 +1,10 @@
+import fields from './fields';
 import vocabularies from './vocabularies';
 
-export default () => ({
+export default () => (configContext) => ({
   recordTypes: {
     chronology: {
+      fields: fields(configContext),
       vocabularies,
     },
   },

--- a/src/plugins/recordTypes/person/fields.js
+++ b/src/plugins/recordTypes/person/fields.js
@@ -7,9 +7,14 @@ export default (configContext) => {
     configKey: config,
   } = configContext.configHelpers;
 
+  const {
+    extensions,
+  } = configContext.config;
+
   return {
     document: {
       'ns2:persons_common': {
+        ...extensions.associatedAuthority.fields,
         personTermGroupList: {
           personTermGroup: {
             termType: {

--- a/src/plugins/recordTypes/person/forms/default.jsx
+++ b/src/plugins/recordTypes/person/forms/default.jsx
@@ -15,6 +15,10 @@ const template = (configContext) => {
     Subrecord,
   } = configContext.recordComponents;
 
+  const {
+    extensions,
+  } = configContext.config;
+
   return (
     <Field name="document">
       <Panel name="info" collapsible>
@@ -199,6 +203,10 @@ const template = (configContext) => {
             </Panel>
           </Field>
         </Field>
+      </Panel>
+
+      <Panel name="authorities" collapsible collapsed>
+        {extensions.associatedAuthority.form}
       </Panel>
 
       <Panel name="hierarchy" collapsible collapsed>

--- a/src/plugins/recordTypes/place/forms/default.jsx
+++ b/src/plugins/recordTypes/place/forms/default.jsx
@@ -155,6 +155,10 @@ const template = (configContext) => {
         </Field>
       </Panel>
 
+      <Panel name="authorities" collapsible collapsed>
+        {extensions.associatedAuthority.form}
+      </Panel>
+
       <Panel name="hierarchy" collapsible collapsed>
         <Field name="relation-list-item" subpath="rel:relations-common-list" />
       </Panel>


### PR DESCRIPTION
**What does this do?**
* Updates associated chronology source to include field collection
* Updates associated concept source to include archculture
* Adds updated associated authorities to chronology, person, and place fields
* Adds associated authorities to person and place forms

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1286

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create a chronology with associated authorities
  * Ideally use a fieldcollection associated chronology and an archculture associated concept
* Create a person with associated authorities
* Create a place with associated authorities

**Dependencies for merging? Releasing to production?**
If you're building with the other associated authority QA PRs, you'll need to build cspace-ui and merge in it's artifacts in order for the field names to be correct when saving.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally