### PR TITLE
DRYD-1498: Add object category fields

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -753,7 +753,7 @@ export default (configContext) => {
             [config]: {
               messages: defineMessages({
                 name: {
-                  id: 'field.procedure.objectCategoryGroup.name',
+                  id: 'field.collectionobjects_objectcategory_extension.objectCategoryGroup.name',
                   defaultMessage: 'Object category',
                 },
               }),
@@ -769,11 +769,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.procedure.category.fullName',
+                    id: 'field.collectionobjects_objectcategory_extension.category.fullName',
                     defaultMessage: 'Object category',
                   },
                   name: {
-                    id: 'field.procedure.category.name',
+                    id: 'field.collectionobjects_objectcategory_extension.category.name',
                     defaultMessage: 'Category',
                   },
                 }),
@@ -790,11 +790,11 @@ export default (configContext) => {
                 dataType: DATA_TYPE_INT,
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.procedure.categoryCount.fullName',
+                    id: 'field.collectionobjects_objectcategory_extension.categoryCount.fullName',
                     defaultMessage: 'Object category count',
                   },
                   name: {
-                    id: 'field.procedure.categoryCount.name',
+                    id: 'field.collectionobjects_objectcategory_extension.categoryCount.name',
                     defaultMessage: 'Count',
                   },
                 }),
@@ -807,11 +807,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.procedure.categoryCountUnit.fullName',
+                    id: 'field.collectionobjects_objectcategory_extension.categoryCountUnit.fullName',
                     defaultMessage: 'Object category unit',
                   },
                   name: {
-                    id: 'field.procedure.categoryCountUnit.name',
+                    id: 'field.collectionobjects_objectcategory_extension.categoryCountUnit.name',
                     defaultMessage: 'Unit',
                   },
                 }),
@@ -827,11 +827,11 @@ export default (configContext) => {
               [config]: {
                 messages: defineMessages({
                   fullName: {
-                    id: 'field.procedure.categoryNote.fullName',
+                    id: 'field.collectionobjects_objectcategory_extension.categoryNote.fullName',
                     defaultMessage: 'Object category note',
                   },
                   name: {
-                    id: 'field.procedure.categoryNote.name',
+                    id: 'field.collectionobjects_objectcategory_extension.categoryNote.name',
                     defaultMessage: 'Note',
                   },
                 }),

--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -737,6 +737,112 @@ export default (configContext) => {
         // collectionobjects_naturalhistory_extension and collectionobjects_anthro.
         ...extensions.locality.fields,
       },
+      'ns2:collectionobjects_objectcategory_extension': {
+        [config]: {
+          service: {
+            ns: 'http://collectionspace.org/services/collectionobject/domain/objectcategory_extension',
+          },
+        },
+        objectCategoryGroupList: {
+          [config]: {
+            view: {
+              type: CompoundInput,
+            },
+          },
+          objectCategoryGroup: {
+            [config]: {
+              messages: defineMessages({
+                name: {
+                  id: 'field.procedure.objectCategoryGroup.name',
+                  defaultMessage: 'Object category',
+                },
+              }),
+              repeating: true,
+              view: {
+                type: CompoundInput,
+                props: {
+                  tabular: true,
+                },
+              },
+            },
+            category: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.procedure.category.fullName',
+                    defaultMessage: 'Object category',
+                  },
+                  name: {
+                    id: 'field.procedure.category.name',
+                    defaultMessage: 'Category',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'objectcategory',
+                  },
+                },
+              },
+            },
+            categoryCount: {
+              [config]: {
+                dataType: DATA_TYPE_INT,
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.procedure.categoryCount.fullName',
+                    defaultMessage: 'Object category count',
+                  },
+                  name: {
+                    id: 'field.procedure.categoryCount.name',
+                    defaultMessage: 'Count',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+            categoryCountUnit: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.procedure.categoryCountUnit.fullName',
+                    defaultMessage: 'Object category unit',
+                  },
+                  name: {
+                    id: 'field.procedure.categoryCountUnit.name',
+                    defaultMessage: 'Unit',
+                  },
+                }),
+                view: {
+                  type: TermPickerInput,
+                  props: {
+                    source: 'objectcountunit',
+                  },
+                },
+              },
+            },
+            categoryNote: {
+              [config]: {
+                messages: defineMessages({
+                  fullName: {
+                    id: 'field.procedure.categoryNote.fullName',
+                    defaultMessage: 'Object category note',
+                  },
+                  name: {
+                    id: 'field.procedure.categoryNote.name',
+                    defaultMessage: 'Note',
+                  },
+                }),
+                view: {
+                  type: TextInput,
+                },
+              },
+            },
+          },
+        },
+      },
       ...extensions.culturalcare.collectionobject.fields,
       ...extensions.nagpra.collectionobject.fields,
       ...extensions.naturalhistory.collectionobject.fields,

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -76,6 +76,15 @@ const template = (configContext) => {
           </Col>
         </Row>
 
+        <Field name="objectCategoryGroupList" subpath="ns2:collectionobjects_objectcategory_extension">
+          <Field name="objectCategoryGroup">
+            <Field name="category" />
+            <Field name="categoryCount" />
+            <Field name="categoryCountUnit" />
+            <Field name="categoryNote" />
+          </Field>
+        </Field>
+
         <Field name="objectNameList">
           <Field name="objectNameGroup">
             <Field name="objectNameControlled" />

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -60,6 +60,15 @@ const template = (configContext) => {
           </Field>
         </Field>
 
+        <Field name="objectCategoryGroupList">
+          <Field name="objectCategoryGroup">
+            <Field name="category" />
+            <Field name="categoryCount" />
+            <Field name="categoryCountUnit" />
+            <Field name="categoryNote" />
+          </Field>
+        </Field>
+
         <Field name="objectNameList">
           <Field name="objectNameGroup">
             <Field name="objectNameControlled" />

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -60,7 +60,7 @@ const template = (configContext) => {
           </Field>
         </Field>
 
-        <Field name="objectCategoryGroupList">
+        <Field name="objectCategoryGroupList" subpath="ns2:collectionobjects_objectcategory_extension">
           <Field name="objectCategoryGroup">
             <Field name="category" />
             <Field name="categoryCount" />


### PR DESCRIPTION
**What does this do?**
* Add object category fields to collectionobject

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1498

This is a new group of fields intended to be used with anthro. 

**How should this be tested? Do these changes have associated tests?**
* Start the devserver: `npm run devserver`
* Create a collectionobject with the object category fields filled out

**Dependencies for merging? Releasing to production?**
Looking at the form again, the `Category` label is kind of redundant. Should probably be fixed before merging.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally 