### PR TITLE
ObjectCountUnit and Related NAGPRA Sidebars

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/corenagpra.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/corenagpra.jsx
@@ -60,6 +60,7 @@ const template = (configContext) => {
         <Field name="objectCountGroupList">
           <Field name="objectCountGroup">
             <Field name="objectCount" />
+            <Field name="objectCountUnit" />
             <Field name="objectCountType" />
             <Field name="objectCountCountedBy" />
             <Field name="objectCountDate" />

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -101,6 +101,7 @@ const template = (configContext) => {
         <Field name="objectCountGroupList">
           <Field name="objectCountGroup">
             <Field name="objectCount" />
+            <Field name="objectCountUnit" />
             <Field name="objectCountType" />
             <Field name="objectCountCountedBy" />
             <Field name="objectCountDate" />

--- a/src/plugins/recordTypes/collectionobject/forms/secondarynagpra.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/secondarynagpra.jsx
@@ -82,6 +82,7 @@ const template = (configContext) => {
         <Field name="objectCountGroupList">
           <Field name="objectCountGroup">
             <Field name="objectCount" />
+            <Field name="objectCountUnit" />
             <Field name="objectCountType" />
             <Field name="objectCountCountedBy" />
             <Field name="objectCountDate" />

--- a/src/plugins/recordTypes/consultation/index.js
+++ b/src/plugins/recordTypes/consultation/index.js
@@ -1,0 +1,11 @@
+import messages from './messages';
+import sidebar from './sidebar';
+
+export default () => ({
+  recordTypes: {
+    consultation: {
+      sidebar,
+      messages,
+    },
+  },
+});

--- a/src/plugins/recordTypes/consultation/messages.js
+++ b/src/plugins/recordTypes/consultation/messages.js
@@ -1,0 +1,10 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  sidebar: defineMessages({
+    nagpra: {
+      id: 'sidebar.consultation.nagpra',
+      defaultMessage: 'NAGPRA',
+    },
+  }),
+};

--- a/src/plugins/recordTypes/consultation/sidebar.js
+++ b/src/plugins/recordTypes/consultation/sidebar.js
@@ -1,0 +1,12 @@
+export default {
+  relatedRecords: [{
+    recordType: 'collectionobject',
+  }, {
+    recordType: 'procedure',
+    serviceTag: '-nagpra',
+  }, {
+    id: 'nagpra',
+    recordType: 'procedure',
+    serviceTag: 'nagpra',
+  }],
+};

--- a/src/plugins/recordTypes/dutyofcare/index.js
+++ b/src/plugins/recordTypes/dutyofcare/index.js
@@ -1,0 +1,11 @@
+import messages from './messages';
+import sidebar from './sidebar';
+
+export default () => ({
+  recordTypes: {
+    dutyofcare: {
+      sidebar,
+      messages,
+    },
+  },
+});

--- a/src/plugins/recordTypes/dutyofcare/messages.js
+++ b/src/plugins/recordTypes/dutyofcare/messages.js
@@ -1,0 +1,10 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  sidebar: defineMessages({
+    nagpra: {
+      id: 'sidebar.dutyofcare.nagpra',
+      defaultMessage: 'NAGPRA',
+    },
+  }),
+};

--- a/src/plugins/recordTypes/dutyofcare/sidebar.js
+++ b/src/plugins/recordTypes/dutyofcare/sidebar.js
@@ -1,0 +1,12 @@
+export default {
+  relatedRecords: [{
+    recordType: 'collectionobject',
+  }, {
+    recordType: 'procedure',
+    serviceTag: '-nagpra',
+  }, {
+    id: 'nagpra',
+    recordType: 'procedure',
+    serviceTag: 'nagpra',
+  }],
+};

--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -2,18 +2,30 @@ import chronology from './chronology';
 import claim from './claim';
 import collectionobject from './collectionobject';
 import concept from './concept';
+import consultation from './consultation';
+import dutyofcare from './dutyofcare';
 import iterationreport from './iterationreport';
+import nagprainventory from './nagprainventory';
 import osteology from './osteology';
 import person from './person';
 import place from './place';
+import repatriationclaim from './repatriationclaim';
+// import restrictedmedia from './restrictedmedia';
+import summarydocumentation from './summarydocumentation';
 
 export default [
   chronology,
   claim,
   collectionobject,
   concept,
+  consultation,
+  dutyofcare,
   iterationreport,
+  nagprainventory,
   osteology,
   person,
   place,
+  repatriationclaim,
+  // restrictedmedia,
+  summarydocumentation,
 ];

--- a/src/plugins/recordTypes/nagprainventory/index.js
+++ b/src/plugins/recordTypes/nagprainventory/index.js
@@ -1,0 +1,11 @@
+import messages from './messages';
+import sidebar from './sidebar';
+
+export default () => ({
+  recordTypes: {
+    nagprainventory: {
+      sidebar,
+      messages,
+    },
+  },
+});

--- a/src/plugins/recordTypes/nagprainventory/messages.js
+++ b/src/plugins/recordTypes/nagprainventory/messages.js
@@ -1,0 +1,10 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  sidebar: defineMessages({
+    nagpra: {
+      id: 'sidebar.nagprainventory.nagpra',
+      defaultMessage: 'NAGPRA',
+    },
+  }),
+};

--- a/src/plugins/recordTypes/nagprainventory/sidebar.js
+++ b/src/plugins/recordTypes/nagprainventory/sidebar.js
@@ -1,0 +1,12 @@
+export default {
+  relatedRecords: [{
+    recordType: 'collectionobject',
+  }, {
+    recordType: 'procedure',
+    serviceTag: '-nagpra',
+  }, {
+    id: 'nagpra',
+    recordType: 'procedure',
+    serviceTag: 'nagpra',
+  }],
+};

--- a/src/plugins/recordTypes/repatriationclaim/index.js
+++ b/src/plugins/recordTypes/repatriationclaim/index.js
@@ -1,0 +1,11 @@
+import messages from './messages';
+import sidebar from './sidebar';
+
+export default () => ({
+  recordTypes: {
+    repatriationclaim: {
+      sidebar,
+      messages,
+    },
+  },
+});

--- a/src/plugins/recordTypes/repatriationclaim/messages.js
+++ b/src/plugins/recordTypes/repatriationclaim/messages.js
@@ -1,0 +1,10 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  sidebar: defineMessages({
+    nagpra: {
+      id: 'sidebar.repatriationclaim.nagpra',
+      defaultMessage: 'NAGPRA',
+    },
+  }),
+};

--- a/src/plugins/recordTypes/repatriationclaim/sidebar.js
+++ b/src/plugins/recordTypes/repatriationclaim/sidebar.js
@@ -1,0 +1,12 @@
+export default {
+  relatedRecords: [{
+    recordType: 'collectionobject',
+  }, {
+    recordType: 'procedure',
+    serviceTag: '-nagpra',
+  }, {
+    id: 'nagpra',
+    recordType: 'procedure',
+    serviceTag: 'nagpra',
+  }],
+};

--- a/src/plugins/recordTypes/restrictedmedia/index.js
+++ b/src/plugins/recordTypes/restrictedmedia/index.js
@@ -1,0 +1,11 @@
+import messages from './messages';
+import sidebar from './sidebar';
+
+export default () => ({
+  recordTypes: {
+    restrictedmedia: {
+      sidebar,
+      messages,
+    },
+  },
+});

--- a/src/plugins/recordTypes/restrictedmedia/messages.js
+++ b/src/plugins/recordTypes/restrictedmedia/messages.js
@@ -1,0 +1,10 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  sidebar: defineMessages({
+    nagpra: {
+      id: 'sidebar.restrictedmedia.nagpra',
+      defaultMessage: 'NAGPRA',
+    },
+  }),
+};

--- a/src/plugins/recordTypes/restrictedmedia/sidebar.js
+++ b/src/plugins/recordTypes/restrictedmedia/sidebar.js
@@ -1,0 +1,12 @@
+export default {
+  relatedRecords: [{
+    recordType: 'collectionobject',
+  }, {
+    recordType: 'procedure',
+    serviceTag: '-nagpra',
+  }, {
+    id: 'nagpra',
+    recordType: 'procedure',
+    serviceTag: 'nagpra',
+  }],
+};

--- a/src/plugins/recordTypes/summarydocumentation/index.js
+++ b/src/plugins/recordTypes/summarydocumentation/index.js
@@ -1,0 +1,11 @@
+import messages from './messages';
+import sidebar from './sidebar';
+
+export default () => ({
+  recordTypes: {
+    summarydocumentation: {
+      sidebar,
+      messages,
+    },
+  },
+});

--- a/src/plugins/recordTypes/summarydocumentation/messages.js
+++ b/src/plugins/recordTypes/summarydocumentation/messages.js
@@ -1,0 +1,10 @@
+import { defineMessages } from 'react-intl';
+
+export default {
+  sidebar: defineMessages({
+    nagpra: {
+      id: 'sidebar.summarydocumentation.nagpra',
+      defaultMessage: 'NAGPRA',
+    },
+  }),
+};

--- a/src/plugins/recordTypes/summarydocumentation/sidebar.js
+++ b/src/plugins/recordTypes/summarydocumentation/sidebar.js
@@ -1,0 +1,12 @@
+export default {
+  relatedRecords: [{
+    recordType: 'collectionobject',
+  }, {
+    recordType: 'procedure',
+    serviceTag: '-nagpra',
+  }, {
+    id: 'nagpra',
+    recordType: 'procedure',
+    serviceTag: 'nagpra',
+  }],
+};


### PR DESCRIPTION
**What does this do?**
* Add objectCountUnit to collectionobject template
* Add Related NAGPRA sidebars to NAGPRA procedures

**Why are we doing this? (with JIRA link)**
* https://collectionspace.atlassian.net/browse/DRYD-1497
* https://collectionspace.atlassian.net/browse/DRYD-1393

The objectCountUnit field was added to core and needed to be added to anthro as it overrode some of the CollectionObject templates.

The Related NAGPRA Sidebars were requested to be added to the new NAGPRA procedures in anthro only, and have had support added in the other layers to do so. This adds the necessary configuration in order to display the relations.

**How should this be tested? Do these changes have associated tests?**
* Run `npm run lint` and `npm run test` as a sanity check
* Run `npm run devserver --back-end=https://anthro.dev.collectionspace.org` 
  * Create a CollectionObject and check that the templates with ObjectCount include ObjectCountUnit
  * Search for a Consultation and see the Related NAGPRA sidebar
  * Search for a Duty of Care and see the Related NAGPRA sidebar
  * Search for a NAGPRA Inventory and see the Related NAGPRA sidebar
  * Search for a Claim and see the Related NAGPRA sidebar (note: the labeling of which claim to use still needs to be done as both claim and repatriationclaim current try to use 'Claim')
  * Search for a Summary Documentation and see the Related NAGPRA sidebar

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with anthro.dev as a backend