### PR TITLE
DRYD-1560: text change in user interface 'Ethnographic Culture(s) -> …

### DIFF
--- a/src/plugins/recordTypes/concept/vocabularies.js
+++ b/src/plugins/recordTypes/concept/vocabularies.js
@@ -28,17 +28,17 @@ export default {
       name: {
         id: 'vocab.concept.ethculture.name',
         description: 'The name of the ethculture concept vocabulary.',
-        defaultMessage: 'Ethnographic Culture',
+        defaultMessage: 'Cultural Group',
       },
       collectionName: {
         id: 'vocab.concept.ethculture.collectionName',
         description: 'The name of a collection of records from the ethculture concept vocabulary.',
-        defaultMessage: 'Ethnographic Cultures',
+        defaultMessage: 'Cultural Groups',
       },
       itemName: {
         id: 'vocab.concept.ethculture.itemName',
         description: 'The name of a record from the vocabulary.',
-        defaultMessage: 'Ethnographic Culture',
+        defaultMessage: 'Cultural Group',
       },
     }),
     serviceConfig: {


### PR DESCRIPTION
**What does this do?**
In the anthro profile, change the text "Ethnographic Culture" or "Ethnographic Cultures" to "Cultural Group" or "Cultural Groups", respectively.

**Why are we doing this? (with JIRA link)**
JIRA ticket: https://collectionspace.atlassian.net/browse/DRYD-1560 (plus the comment thread)

**How should this be tested? Do these changes have associated tests?**
- Make sure CSpace is running and was configured with the `CSPACE_ANTHRO_UI_BASE_URL_OPT` environmental variable set appropriately (or equivalent)
- Clone this version of [cspace-ui-plugin-profile-anthro.js](https://github.com/collectionspace/cspace-ui-plugin-profile-anthro.js)
- Enter `cspace-ui-plugin-profile-anthro.js`
- Edit `package.json` and `package-lock.json` and in each change ` "cspace-ui": "^10.0.0-rc.1"` to ` "cspace-ui": "^10.0.0-rc.5"` under `devDependencies` (for testing in a dev environment)
- Issue `npm install` to install it, `npm run devserver` to run the anthro profile dev server
- Hit the URL $CSPACE_ANTHRO_UI_BASE_URL_OPT set in the 1st step in a web browser
- Click Create New. Under Authorities -> Concept, you should see **Cultural Group** and not **Ethnographic Culture** (see 1st screenshot)
- Click Objects -> Object and open the Repatriation and NAGPRA Compliance Information accordion. Enter random text like "ddd" into Cultural determination -> Culture. You should see **+ Cultural Groups** as a suggestion and not **+ Ethnographic Culture** (see 2nd screenshot)

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@axb21 ran the procedure above locally.

## Screenshots
1. ![screenshot1](https://github.com/user-attachments/assets/042dcade-29a4-4c3a-84de-0106444de636)
2. ![screenshot2](https://github.com/user-attachments/assets/293f0577-db23-4454-9e25-5360882dd4c2)
