### PR TITLE
DRYD-1781: Updates to Public Browser Template

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -111,6 +111,10 @@ const template = (configContext) => {
               <Field name="contentConcepts">
                 <Field name="contentConcept" />
               </Field>
+
+              <Field name="contentEvents">
+                <Field name="contentEvent" />
+              </Field>
             </Col>
 
             <Col>
@@ -121,11 +125,7 @@ const template = (configContext) => {
               <Field name="contentOrganizations">
                 <Field name="contentOrganization" />
               </Field>
-
-              <Field name="contentEvents">
-                <Field name="contentEvent" />
-              </Field>
-            </Col>
+           </Col>
           </Cols>
         </Panel>
 

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -42,26 +42,8 @@ const template = (configContext) => {
         </Row>
 
         <Field name="titleGroupList">
-          <Field name="titleGroup">
-            <Panel>
-              <Row>
-                <Col>
-                  <Field name="title" />
-                  <Field name="titleLanguage" />
-                </Col>
-
-                <Col>
-                  <Field name="titleType" />
-
-                  <Field name="titleTranslationSubGroupList">
-                    <Field name="titleTranslationSubGroup">
-                      <Field name="titleTranslation" />
-                      <Field name="titleTranslationLanguage" />
-                    </Field>
-                  </Field>
-                </Col>
-              </Row>
-            </Panel>
+          <Field name="titleGroup" tabular={true} label={null}>
+            <Field name="title" />
           </Field>
         </Field>
 

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -78,34 +78,27 @@ const template = (configContext) => {
           <Field name="objectNameGroup">
             <Field name="objectNameControlled" />
             <Field name="objectName" />
-            <Field name="objectNameCurrency" />
-            <Field name="objectNameLevel" />
-            <Field name="objectNameSystem" />
-            <Field name="objectNameType" />
-            <Field name="objectNameLanguage" />
-            <Field name="objectNameNote" />
           </Field>
         </Field>
 
       </Panel>
 
       <Panel name="desc" collapsible>
-        <Field name="colors">
-          <Field name="color" />
-        </Field>
-
         <Field name="materialGroupList">
           <Field name="materialGroup">
             <Field name="materialControlled" />
             <Field name="material" />
-            <Field name="materialComponent" />
-            <Field name="materialComponentNote" />
-            <Field name="materialName" />
-            <Field name="materialSource" />
           </Field>
         </Field>
 
-        {extensions.dimension.form}
+        <Field name="measuredPartGroupList">
+          <Field name="measuredPartGroup" tabular={true}>
+            <Row>
+              <Field name="measuredPart" />
+              <Field name="dimensionSummary" />
+            </Row>
+          </Field>
+        </Field>
 
         <Panel name="content" collapsible>
           <Field name="contentDescription" />
@@ -194,18 +187,6 @@ const template = (configContext) => {
             </Field>
           </Col>
         </Row>
-      </Panel>
-
-      <Panel name="hist" collapsible>
-        <Field name="objectHistoryNote" />
-      </Panel>
-
-      <Panel name="owner" collapsible>
-        <Field name="ownersContributionNote" />
-      </Panel>
-
-      <Panel name="viewer" collapsible>
-        <Field name="viewersContributionNote" />
       </Panel>
 
       <Panel name="reference" collapsible collapsed>

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -84,6 +84,10 @@ const template = (configContext) => {
       </Panel>
 
       <Panel name="desc" collapsible>
+        <Field name="colors">
+          <Field name="color" />
+        </Field>
+
         <Field name="materialGroupList">
           <Field name="materialGroup">
             <Field name="materialControlled" />

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -42,8 +42,26 @@ const template = (configContext) => {
         </Row>
 
         <Field name="titleGroupList">
-          <Field name="titleGroup" tabular={true} label={null}>
-            <Field name="title" />
+          <Field name="titleGroup">
+            <Panel>
+              <Row>
+                <Col>
+                  <Field name="title" />
+                  <Field name="titleLanguage" />
+                </Col>
+
+                <Col>
+                  <Field name="titleType" />
+
+                  <Field name="titleTranslationSubGroupList">
+                    <Field name="titleTranslationSubGroup">
+                      <Field name="titleTranslation" />
+                      <Field name="titleTranslationLanguage" />
+                    </Field>
+                  </Field>
+                </Col>
+              </Row>
+            </Panel>
           </Field>
         </Field>
 

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -96,7 +96,7 @@ const template = (configContext) => {
         </Field>
 
         <Field name="measuredPartGroupList">
-          <Field name="measuredPartGroup" tabular={true}>
+          <Field name="measuredPartGroup" tabular>
             <Row>
               <Field name="measuredPart" />
               <Field name="dimensionSummary" />
@@ -125,7 +125,7 @@ const template = (configContext) => {
               <Field name="contentOrganizations">
                 <Field name="contentOrganization" />
               </Field>
-           </Col>
+            </Col>
           </Cols>
         </Panel>
 

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -5,6 +5,7 @@ const template = (configContext) => {
 
   const {
     Col,
+    Cols,
     Panel,
     Row,
   } = configContext.layoutComponents;
@@ -32,6 +33,10 @@ const template = (configContext) => {
           <Col>
             <Field name="briefDescriptions">
               <Field name="briefDescription" />
+            </Field>
+
+            <Field name="publishToList">
+              <Field name="publishTo" />
             </Field>
           </Col>
         </Row>
@@ -103,9 +108,28 @@ const template = (configContext) => {
         {extensions.dimension.form}
 
         <Panel name="content" collapsible>
-          <Field name="contentConcepts">
-            <Field name="contentConcept" />
-          </Field>
+          <Field name="contentDescription" />
+          <Cols>
+            <Col>
+              <Field name="contentConcepts">
+                <Field name="contentConcept" />
+              </Field>
+            </Col>
+
+            <Col>
+              <Field name="contentPersons">
+                <Field name="contentPerson" />
+              </Field>
+
+              <Field name="contentOrganizations">
+                <Field name="contentOrganization" />
+              </Field>
+
+              <Field name="contentEvents">
+                <Field name="contentEvent" />
+              </Field>
+            </Col>
+          </Cols>
         </Panel>
 
         <Panel name="bio" collapsible collapsed>
@@ -130,6 +154,13 @@ const template = (configContext) => {
           <Col>
             <Field name="objectProductionDateGroupList">
               <Field name="objectProductionDateGroup" />
+            </Field>
+
+            <Field name="techniqueGroupList">
+              <Field name="techniqueGroup">
+                <Field name="technique" />
+                <Field name="techniqueType" />
+              </Field>
             </Field>
 
             <Field name="objectProductionPlaceGroupList">


### PR DESCRIPTION
**What does this do?**
This makes changes to the public browser template based on what is visible in the public browser.

Fields Added:

- Publish To
- Technique and Technique Type
- Content Description
- Concept Event or period/era
- Concept Person
- Concept Organization

Fields Removed:

- Object History Note
- Owner Contribution
- Viewer Contribution

Field Group Changes:
- Object Name Group: Keep Object Name Controlled and Object Name, remove others
- Material Group: Keep Material Controlled and Material, remove others
- Dimension: Keep Dimension Measurement Part and Dimension Summary, remove others

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1781

Changes to the elastic search index have been made without making updates to the public browser template, resulting in it being out of date. In addition, although some field groups are indexed entirely not all fields are displayed in the browser. We felt it was better to remove the non-displayed fields, with the exception of the Title group which has styling concerns and will have to be revisited.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g. `npm run devserver --back-end=https://anthro.dev.collectionspace.org`
* Create a new collection object using the public browser template
* See the changes listed above

**Dependencies for merging? Releasing to production?**
The `color` field was slated to be removed, but we noticed it exists as a facet in the anthro config. We've decided to keep it and add it to the display in the public browser for anthro.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested with anthro.dev as a backend