### PR TITLE
DRYD-1744: Remove anthroOwnershipAccess

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -262,26 +262,6 @@ export default (configContext) => {
                 },
               },
             },
-            anthroOwnershipAccess: {
-              [config]: {
-                messages: defineMessages({
-                  fullName: {
-                    id: 'field.collectionobjects_anthro.anthroOwnershipAccess.fullName',
-                    defaultMessage: 'Previous ownership access',
-                  },
-                  name: {
-                    id: 'field.collectionobjects_anthro.anthroOwnershipAccess.name',
-                    defaultMessage: 'Access',
-                  },
-                }),
-                view: {
-                  type: OptionPickerInput,
-                  props: {
-                    source: 'ownershipAccessLevels',
-                  },
-                },
-              },
-            },
             anthroOwnershipDateGroup: {
               [config]: {
                 dataType: DATA_TYPE_STRUCTURED_DATE,


### PR DESCRIPTION
**What does this do?**
This removes `anthroOwnershipAccess` from the anthro-collectionobject schema

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1744

This field was originally added with the `anthroOwnershipGroup` but was never added to the ui. We're opting to remove it since we haven't heard any requests for it.

**How should this be tested? Do these changes have associated tests?**
* Run the dev server (e.g. `npm run devserver --back-end=https://anthro.dev.collectionspace.org`
* Navigate to the Ownership section for collectionobjects and see that the field group can be fully populated
* In the advanced search, check that `Previous owner access` does not show up as a field for collection objects

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against anthro.dev