### PR TITLE
Update cspace-ui-plugin-ext-nagpra to 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4162,9 +4162,9 @@
       }
     },
     "node_modules/cspace-ui-plugin-ext-nagpra": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cspace-ui-plugin-ext-nagpra/-/cspace-ui-plugin-ext-nagpra-2.0.1.tgz",
-      "integrity": "sha512-SwoygsoW/a/Ua+NEWAOqsZO3keV/nn23Qb9oBBgDzxlQLsiZdNywgdJBuKL71Hr6pWR3dvSWyspNLgHYRtQYEw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/cspace-ui-plugin-ext-nagpra/-/cspace-ui-plugin-ext-nagpra-2.0.2.tgz",
+      "integrity": "sha512-x6gxDlgJJdo/HpNvpcaJOWRK7vaP1BDHuoAVtcSBfgK5rlRLHBIGGH38jEWcXAsOQDS+oTPqMb6E5G3tYmIdLA==",
       "dependencies": {
         "react-intl": "^2.3.0"
       }


### PR DESCRIPTION
**What does this do?**
Update cspace-ui-plugin-ext-nagpra.js to 2.0.2

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1719

This is a followup for DRYD-1719 to update the package-lock so that the updated version of the NAGPRA extension is pulled.

**How should this be tested? Do these changes have associated tests?**
* Remove your existing node_modules directory
* Run `npm i`
* Check that the installed version of the NAGPRA extension is 2.0.2, e.g.
`grep version node_modules/cspace-ui-plugin-ext-nagpra/package.json`

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally