### PR TITLE
DRYD-1880: Template > Anthro > Modify Core NAGPRA

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/corenagpra.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/corenagpra.jsx
@@ -57,6 +57,19 @@ const template = (configContext) => {
           </Field>
         </Field>
 
+        <Field name="objectNameList">
+          <Field name="objectNameGroup">
+            <Field name="objectNameControlled" />
+            <Field name="objectName" />
+            <Field name="objectNameCurrency" />
+            <Field name="objectNameLevel" />
+            <Field name="objectNameSystem" />
+            <Field name="objectNameType" />
+            <Field name="objectNameLanguage" />
+            <Field name="objectNameNote" />
+          </Field>
+        </Field>
+
         <Field name="objectCountGroupList">
           <Field name="objectCountGroup">
             <Field name="objectCount" />
@@ -112,6 +125,21 @@ const template = (configContext) => {
 
       {extensions.nagpra.collectionobject.form}
       {extensions.culturalcare.collectionobject.form}
+
+      <Panel name="ownership" collapsible collapsed>
+        <Field name="anthroOwnershipGroupList" subpath="ns2:collectionobjects_anthro">
+          <Field name="anthroOwnershipGroup" label="">
+            <Field name="anthroOwner" />
+            <Field name="anthroOwnershipDateGroup" />
+            <Field name="anthroOwnershipCategory" />
+            <Field name="anthroOwnershipPlace" />
+            <Field name="anthroOwnershipMethod" />
+            <Field name="anthroOwnershipPriceCurrency" />
+            <Field name="anthroOwnershipPriceAmount" />
+            <Field name="anthroOwnershipNote" />
+          </Field>
+        </Field>
+      </Panel>
 
     </Field>
   );

--- a/src/plugins/recordTypes/collectionobject/forms/secondarynagpra.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/secondarynagpra.jsx
@@ -54,6 +54,10 @@ const template = (configContext) => {
             </Field>
 
             <Field name="computedCurrentLocation" />
+
+            <Field name="ethnoFileCodes" subpath="ns2:collectionobjects_anthro">
+              <Field name="ethnoFileCode" />
+            </Field>
           </Col>
         </Row>
 
@@ -231,177 +235,14 @@ const template = (configContext) => {
 
       <Panel name="desc" collapsible collapsed>
         <Row>
-          <Col>
-            <Field name="forms">
-              <Field name="form" />
-            </Field>
+          <Field name="colors">
+            <Field name="color" />
+          </Field>
 
-            <Row>
-              <Field name="copyNumber" />
-              <Field name="editionNumber" />
-            </Row>
-          </Col>
-
-          <Col>
-            <Field name="styles">
-              <Field name="style" />
-            </Field>
-
-            <Field name="colors">
-              <Field name="color" />
-            </Field>
-
-            <Field name="apparelSizes">
-              <Field name="apparelSize" />
-            </Field>
-          </Col>
+          <Field name="apparelSizes">
+            <Field name="apparelSize" />
+          </Field>
         </Row>
-
-        <Field name="physicalDescription" />
-        <Field name="distinguishingFeatures" />
-
-        <Field name="objectComponentGroupList">
-          <Field name="objectComponentGroup">
-            <Field name="objectComponentName" />
-            <Field name="objectComponentInformation" />
-          </Field>
-        </Field>
-
-        <Panel name="bio" collapsible collapsed>
-          <Cols>
-            <Col>
-              <Row>
-                <Field name="sex" />
-                <Field name="phase" />
-              </Row>
-            </Col>
-
-            <Col>
-              <InputTable name="age">
-                <Field name="ageQualifier" />
-                <Field name="age" />
-                <Field name="ageUnit" />
-              </InputTable>
-            </Col>
-          </Cols>
-
-          {extensions.naturalhistory.collectionobject.form.taxonomicIdentGroupList}
-        </Panel>
-
-        <Panel name="commingledRemains" collapsible collapsed>
-          <Field name="commingledRemainsGroupList" subpath="ns2:collectionobjects_anthro">
-            <Field name="commingledRemainsGroup">
-              <Panel>
-                <Cols>
-                  <Col>
-                    <Field name="minIndividuals" />
-                    <Field name="bone" />
-                    <Field name="side" />
-                  </Col>
-
-                  <Col>
-                    <Row>
-                      <Field name="count" />
-                      <Field name="dentition" />
-                    </Row>
-
-                    <Field name="sex" />
-                    <Field name="ageRange" />
-                  </Col>
-                </Cols>
-
-                <Field name="mortuaryTreatmentGroupList">
-                  <Field name="mortuaryTreatmentGroup">
-                    <Field name="mortuaryTreatment" />
-                    <Field name="mortuaryTreatmentNote" />
-                  </Field>
-                </Field>
-
-                <InputTable name="behrensmeyer">
-                  <Field name="behrensmeyerSingleLower" />
-                  <Field name="behrensmeyerUpper" />
-                </InputTable>
-
-                <Field name="commingledRemainsNote" />
-              </Panel>
-            </Field>
-          </Field>
-        </Panel>
-
-        <Panel name="content" collapsible collapsed>
-          <Field name="contentDescription" />
-
-          <Row>
-            <Col>
-              <Field name="contentLanguages">
-                <Field name="contentLanguage" />
-              </Field>
-
-              <Field name="contentActivities">
-                <Field name="contentActivity" />
-              </Field>
-
-              <Field name="contentConcepts">
-                <Field name="contentConcept" />
-              </Field>
-
-              <Field name="contentDateGroup" />
-
-              <Field name="contentPositions">
-                <Field name="contentPosition" />
-              </Field>
-
-              <Field name="contentObjectGroupList">
-                <Field name="contentObjectGroup">
-                  <Field name="contentObject" />
-                  <Field name="contentObjectType" />
-                </Field>
-              </Field>
-            </Col>
-
-            <Col>
-              <Field name="contentPeoples">
-                <Field name="contentPeople" />
-              </Field>
-
-              <Field name="contentPersons">
-                <Field name="contentPerson" />
-              </Field>
-
-              <Field name="contentPlaces">
-                <Field name="contentPlace" />
-              </Field>
-
-              <Field name="contentScripts">
-                <Field name="contentScript" />
-              </Field>
-
-              <Field name="contentOrganizations">
-                <Field name="contentOrganization" />
-              </Field>
-
-              <Field name="contentEventNameGroupList">
-                <Field name="contentEventNameGroup">
-                  <Field name="contentEventName" />
-                  <Field name="contentEventNameType" />
-                </Field>
-              </Field>
-
-              <Field name="contentEvents">
-                <Field name="contentEvent" />
-              </Field>
-
-              <Field name="contentOtherGroupList">
-                <Field name="contentOtherGroup">
-                  <Field name="contentOther" />
-                  <Field name="contentOtherType" />
-                </Field>
-              </Field>
-            </Col>
-          </Row>
-
-          <Field name="contentNote" />
-        </Panel>
 
         <Panel name="textInscript" collapsible collapsed>
           <Field name="textualInscriptionGroupList">

--- a/src/plugins/recordTypes/collectionobject/forms/secondarynagpra.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/secondarynagpra.jsx
@@ -7,14 +7,12 @@ const template = (configContext) => {
 
   const {
     Col,
-    Cols,
     Panel,
     Row,
   } = configContext.layoutComponents;
 
   const {
     Field,
-    InputTable,
   } = configContext.recordComponents;
 
   const {

--- a/src/plugins/recordTypes/collectionobject/messages.js
+++ b/src/plugins/recordTypes/collectionobject/messages.js
@@ -31,6 +31,10 @@ export default (configContext) => {
           id: 'panel.collectionobject.locality',
           defaultMessage: 'Locality Information',
         },
+        ownership: {
+          id: 'panel.collectionobject.ownership',
+          defaultMessage: 'Previous Ownership Information',
+        },
       }),
       ...extensions.culturalcare.collectionobject.messages.panel,
       ...extensions.locality.messages.panel,


### PR DESCRIPTION
**What does this do?**
* Adds the `objectNameList` and `anthroOwnershipGroupList` to the `corenagpra` template.
* Adds a default message `Previous Ownership Information` to show in the expandable Panel.
* Applies the `secondarynagpra` template changes defined in [DRYD-1881](https://collectionspace.atlassian.net/browse/DRYD-1881)


**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-1880
https://collectionspace.atlassian.net/browse/DRYD-1881

**How should this be tested? Do these changes have associated tests?**
Please run the cspace-ui-plugin-profile-anthro and check that the fields are shown when selecting the Core NAGPRA template in the edit object/create object views. They should also work as expected when adding values to the fields.
* The object name block should be shown in the “Object Identification Information” panel after “Object category“ group. Same to the “Standard Template“
* The previous owner block should be shown in its own panel at the bottom, after “Cultural Care Information“

Please also check that the DRYD-1881 changes work as expected when selecting the "Secondary NAGPRA" template.

**Dependencies for merging? Releasing to production?**
No dependencies

**Has the application documentation been updated for these changes?**
I haven't found any relevant documentation to update.

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally with anthro dev server as backend