### PR TITLE
DRYD-1973: Update tags section to include NAGPRA Determinations

### DIFF
--- a/src/plugins/recordTypes/collectionobject/detailList.jsx
+++ b/src/plugins/recordTypes/collectionobject/detailList.jsx
@@ -1,0 +1,80 @@
+export default (configContext) => {
+  const {
+    React,
+    Immutable,
+    FormattedMessage,
+  } = configContext.lib;
+
+  const {
+    formatRefName,
+  } = configContext.formatHelpers;
+
+  return {
+    tags: {
+      formatter: (data, separator = ', ') => {
+        let concepts;
+        const contentConcepts = data.get('contentConcepts');
+        if (contentConcepts) {
+          let conceptTags;
+          const conceptPrefix = (
+            <FormattedMessage
+              id="detailList.collectionobject.concepts"
+              description="The prefix for content concept tags in the search detail view"
+              defaultMessage="Content Concepts: "
+            />
+          );
+          const contentConcept = contentConcepts.get('contentConcept');
+          if (Immutable.List.isList(contentConcept)) {
+            conceptTags = contentConcept.filter((concept) => !!concept)
+              .map((concept) => formatRefName(concept))
+              .join(separator);
+          } else {
+            conceptTags = formatRefName(contentConcept);
+          }
+
+          concepts = (
+            <p>
+              {conceptPrefix}
+              {conceptTags}
+            </p>
+          );
+        }
+
+        let determinations;
+        const nagpraCategories = data.get('nagpraCategories');
+        if (nagpraCategories) {
+          let nagpraDeterminations;
+          const nagpraPrefix = (
+            <FormattedMessage
+              id="detailList.collectionobject.determinations"
+              description="The prefix for NAGPRA determination tags in the search detail view"
+              defaultMessage="NAGPRA Determinations: "
+            />
+          );
+
+          const nagpraCategory = nagpraCategories.get('nagpraCategory');
+          if (Immutable.List.isList(nagpraCategory)) {
+            nagpraDeterminations = nagpraCategory.filter((category) => !!category)
+              .map((category) => formatRefName(category))
+              .join(separator);
+          } else {
+            nagpraDeterminations = formatRefName(nagpraCategory);
+          }
+          determinations = (
+            <p>
+              {nagpraPrefix}
+              {nagpraDeterminations}
+            </p>
+          );
+        }
+
+        return (
+          <>
+            {concepts}
+            {determinations}
+          </>
+        );
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/collectionobject/index.js
+++ b/src/plugins/recordTypes/collectionobject/index.js
@@ -1,5 +1,6 @@
 import advancedSearch from './advancedSearch';
 import columns from './columns';
+import detailList from './detailList';
 import forms from './forms';
 import fields from './fields';
 import messages from './messages';
@@ -11,6 +12,7 @@ export default () => (configContext) => ({
     collectionobject: {
       advancedSearch: advancedSearch(configContext),
       columns: columns(configContext),
+      detailList: detailList(configContext),
       forms: forms(configContext),
       fields: fields(configContext),
       messages: messages(configContext),


### PR DESCRIPTION
**What does this do?**
* Adds NAGPRRA Determinations to tags section

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1973

This updates the anthro profile to include NAGPRA Determinations when they are present. 

**How should this be tested? Do these changes have associated tests?**
* Run the profile plugin, e.g. `npm run devserver`
  * At this point the backend should be responding with all fields required for this PR, so the `--back-end` flag can be used
* Run a search for 'Objects' and switch to the 'list' view
* See that `NAGPRA Determinations` show up for objects in addition to the existing fields which are displayed

**Dependencies for merging? Releasing to production?**
This requires https://github.com/collectionspace/cspace-ui.js/pull/299 in order to run.

**Has the application documentation been updated for these changes?**
No. We should see if there's docs for configuration which should have the new file added to it.

**Did someone actually run this code to verify it works?**
@mikejritter tested locally