### PR TITLE
DRYD-1981: Add NAGPRA-eligible tag formatter

### DIFF
--- a/src/plugins/recordTypes/collectionobject/grid.jsx
+++ b/src/plugins/recordTypes/collectionobject/grid.jsx
@@ -13,7 +13,7 @@ export default (configContext) => {
         if (nagpraCategoriesList) {
           const nagpraCategories = nagpraCategoriesList.get('nagpraCategory');
           if (Immutable.List.isList(nagpraCategories)) {
-            nagpraEligible = nagpraCategories.filter((category) => !!category).length > 1;
+            nagpraEligible = nagpraCategories.filter((category) => !!category).size > 1;
           } else {
             nagpraEligible = nagpraCategories && nagpraCategories.length > 0;
           }

--- a/src/plugins/recordTypes/collectionobject/grid.jsx
+++ b/src/plugins/recordTypes/collectionobject/grid.jsx
@@ -1,0 +1,34 @@
+export default (configContext) => {
+  const {
+    React,
+    Immutable,
+    FormattedMessage,
+  } = configContext.lib;
+
+  return {
+    tags: {
+      formatter: (data) => {
+        let nagpraEligible;
+        const nagpraCategoriesList = data.get('nagpraCategories');
+        if (nagpraCategoriesList) {
+          const nagpraCategories = nagpraCategoriesList.get('nagpraCategory');
+          if (Immutable.List.isList(nagpraCategories)) {
+            nagpraEligible = nagpraCategories.filter((category) => !!category).length > 1;
+          } else {
+            nagpraEligible = nagpraCategories && nagpraCategories.length > 0;
+          }
+        }
+
+        const eligible = (
+          <FormattedMessage
+            id="grid.collectionobject.nagpraEligible"
+            description="The text for NAGPRA eligible results the search grid view"
+            defaultMessage="NAGPRA-eligible"
+          />
+        );
+
+        return nagpraEligible ? <p>{eligible}</p> : null;
+      },
+    },
+  };
+};

--- a/src/plugins/recordTypes/collectionobject/index.js
+++ b/src/plugins/recordTypes/collectionobject/index.js
@@ -3,6 +3,7 @@ import columns from './columns';
 import detailList from './detailList';
 import forms from './forms';
 import fields from './fields';
+import grid from './grid';
 import messages from './messages';
 import optionLists from './optionLists';
 
@@ -15,6 +16,7 @@ export default () => (configContext) => ({
       detailList: detailList(configContext),
       forms: forms(configContext),
       fields: fields(configContext),
+      grid: grid(configContext),
       messages: messages(configContext),
     },
   },


### PR DESCRIPTION
**What does this do?**
Adds NAGPRA-eligible to the tag formatter

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1981

The NAGPRA-eligible text is not available in other profiles, and is being added here for the anthro profile only.

**How should this be tested? Do these changes have associated tests?**
* Note that this requires cspace-ui to be updated with the grid PR
  * I also noticed that I could not use anthro.dev as a backend (I believe it fetches cspace-ui from unpkg?), so this had to be tested locally 
* Run the devserver
* Run a search on Objects
* For objects with Museum NAGPRA Category Determinations set, you should see the `NAGPRA-eligible` text

**Dependencies for merging? Releasing to production?**
Requires https://github.com/collectionspace/cspace-ui.js/pull/304

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally