### PR TITLE
DRYD-1904: Object Record > Anthro > Add Material/technique description

### DIFF
--- a/src/plugins/recordTypes/collectionobject/fields.js
+++ b/src/plugins/recordTypes/collectionobject/fields.js
@@ -712,6 +712,19 @@ export default (configContext) => {
             },
           },
         },
+        materialTechniqueDescription: {
+          [config]: {
+            messages: defineMessages({
+              name: {
+                id: 'field.collectionobjects_anthro.materialTechniqueDescription.name',
+                defaultMessage: 'Material/technique description',
+              },
+            }),
+            view: {
+              type: TextInput,
+            },
+          },
+        },
         // FIXME: Locality was added for DRYD-400, but I didn't realize locality was already
         // included by the naturalhistory extension, so the locality fields are duplicated in both
         // collectionobjects_naturalhistory_extension and collectionobjects_anthro.

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -142,6 +142,8 @@ const template = (configContext) => {
 
         {extensions.dimension.form}
 
+        <Field name="materialTechniqueDescription" subpath="ns2:collectionobjects_anthro" />
+
         <Field name="materialGroupList">
           <Field name="materialGroup">
             <Field name="materialControlled" />


### PR DESCRIPTION
**What does this do?**
It adds the `materialTechniqueDescription` field in the default template.

**Why are we doing this? (with JIRA link)**
https://collectionspace.atlassian.net/browse/DRYD-1904

**How should this be tested? Do these changes have associated tests?**
* Please build the application with the https://github.com/collectionspace/application/pull/326 updates and redeploy.
* Start the anthro plugin locally, using local backend.
* Create a new object and set a value to the "Material/technique description" field.
* Confirm that the field is being populated after successful saving. Please also refresh the page and reconfirm.

**Dependencies for merging? Releasing to production?**
https://github.com/collectionspace/application/pull/326  is a dependency

**Has the application documentation been updated for these changes?**
No need to update documentation

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally using local backend with the https://github.com/collectionspace/application/pull/326 updates.
