### PR TITLE
Release 9.2.0-rc1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## v9.2.0
+
+v9.2.0 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.
+
+### Changes
+- Adds `objectNameList`, `anthroOwnershipGroupList` to the `corenagpra` template.
+- Changes `secondarynagpra` template by removing several fields and adding `function` field.
+- Adds the `materialTechniqueDescription` to the default template.
+- Adds `nagpraDeterminations` to `tags` section.
+- Adds the `NAGPRA-eligible` tag formatter.
+
 ## v9.1.0
 
 v9.0.0 adds support for CollectionSpace 8.2, and requires cspace-ui version 10.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-anthro",
-  "version": "9.1.0",
+  "version": "9.2.0-rc1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-anthro",
-  "version": "9.1.0",
+  "version": "9.2.0-rc1.0",
   "description": "Anthropology profile plugin for the CollectionSpace UI",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",


### PR DESCRIPTION
**What does this do?**
This updates the package version to 9.2.0-rc1.0 to signify the next release. It also updates the changelog.

When the PR is merged we can publish the relevant draft release https://github.com/collectionspace/cspace-ui-plugin-profile-anthro.js/releases

***Dependency for merging***
The https://github.com/collectionspace/cspace-ui-plugin-profile-anthro.js/pull/39 needs to be merged first
