### PR TITLE
DRYD-2019: Add controlled content place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v9.2.0 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.
 - Adds the `materialTechniqueDescription` to the default template.
 - Adds `nagpraDeterminations` to `tags` section.
 - Adds the `NAGPRA-eligible` tag formatter.
+- Add the `controlledContentPlaces/controlledContentPlace` repeatable field to the Object `default` template.
 
 ## v9.1.0
 

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -438,6 +438,10 @@ const template = (configContext) => {
                 <Field name="contentPerson" />
               </Field>
 
+              <Field name="controlledContentPlaces">
+                <Field name="controlledContentPlace" />
+              </Field>
+
               <Field name="contentPlaces">
                 <Field name="contentPlace" />
               </Field>


### PR DESCRIPTION
**What does this do?**
* Adds the controlled content place field to the default template for collection objects

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2019

This is a field which is needed for an upcoming data migration.

**How should this be tested? Do these changes have associated tests?**

* Rebuild and start CollectionSpace with the [application PR](https://github.com/collectionspace/application/pull/333) and the [cspace-ui.js PR](https://github.com/collectionspace/cspace-ui.js/pull/330)
* Run the devserver
* Create a new CollectionObject
  * Populate the new field under `Object Description Information > Content > Place (controlled)`
  * Save and reload to ensure the field populated
* Use the AdvancedSearch for a CollectionObject
  * Verify that the controlled field shows up under the fields

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
The changelog has been updated

**Did someone actually run this code to verify it works?**
@mikejritter tested locally