### PR TITLE
DRYD-1973: Formatting for NAGPRA Determination

### DIFF
--- a/src/plugins/recordTypes/collectionobject/detailList.jsx
+++ b/src/plugins/recordTypes/collectionobject/detailList.jsx
@@ -5,13 +5,13 @@ const messages = defineMessages({
     id: 'detailList.tags.collectionobject.concepts',
     description: 'The prefix for content concept tags in the search detail view',
     defaultMessage: `{count, plural,
-              one {CONCEPT TAG: }
-              other {CONCEPT TAGS: }}`,
+              one {Concept Tag: }
+              other {Concept Tags: }}`,
   },
   determination: {
     id: 'detailList.tags.collectionobject.determinations',
     description: 'The prefix for NAGPRA determination tags in the search detail view',
-    defaultMessage: 'NAGPRA DETERMINATION: {nagpraDeterminations}',
+    defaultMessage: 'NAGPRA Determination: {nagpraDeterminations}',
   },
 });
 

--- a/src/plugins/recordTypes/collectionobject/detailList.jsx
+++ b/src/plugins/recordTypes/collectionobject/detailList.jsx
@@ -11,7 +11,7 @@ const messages = defineMessages({
   determination: {
     id: 'detailList.tags.collectionobject.determinations',
     description: 'The prefix for NAGPRA determination tags in the search detail view',
-    defaultMessage: 'NAGPRA DETERMINATION: ',
+    defaultMessage: 'NAGPRA DETERMINATION: {nagpraDeterminations}',
   },
 });
 
@@ -64,10 +64,10 @@ export default (configContext) => {
           } else {
             nagpraDeterminations = formatRefName(nagpraCategory);
           }
+
           determinations = (
             <p>
-              <span>{intl.formatMessage(messages.determination)}</span>
-              {nagpraDeterminations}
+              <span>{intl.formatMessage(messages.determination, { nagpraDeterminations })}</span>
             </p>
           );
         }


### PR DESCRIPTION
**What does this do?**
* Preserve the space when formatting NAGPRA Determinations

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1973

When looking at the formatting of the Content Concepts and NAGPRA Determinations, we noticed that there was not a space between the NAGPRA Determination prefix and the text. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Run a search on Objects
  * It's useful to include `Museum NAGPRA category determination` is not blank
* See that the space is included in the NAGPRA Determination section.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
None

**Did someone actually run this code to verify it works?**
@mikejritter tested using anthro.dev as a backend