### PR TITLE
Release 9.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ v9.2.0 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.
 
 ## v9.1.0
 
-v9.0.0 adds support for CollectionSpace 8.2, and requires cspace-ui version 10.
+v9.1.0 adds support for CollectionSpace 8.2, and requires cspace-ui version 10.
 
 ### Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-ui-plugin-profile-anthro",
-  "version": "9.2.0-rc1.0",
+  "version": "9.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-ui-plugin-profile-anthro",
-      "version": "9.1.0",
+      "version": "9.2.0",
       "license": "ECL-2.0",
       "dependencies": {
         "cspace-ui-plugin-ext-culturalcare": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-ui-plugin-profile-anthro",
-  "version": "9.2.0-rc1.0",
+  "version": "9.2.0",
   "description": "Anthropology profile plugin for the CollectionSpace UI",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",


### PR DESCRIPTION
What does this do?
This updates the package version to 9.2.0 to signify the next release.

When the PR is merged we can publish the relevant draft release https://github.com/collectionspace/cspace-ui-plugin-profile-anthro.js/releases/edit/untagged-108ea61f48a5a98f56a8